### PR TITLE
v0.1.2 - Move OAuth logic into TokenResolver task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.2
+
++ Move OAuth logic into TokenResolver task
++ Fix mocked HTTP responses in tests
+
 # v0.1.1
 
 + Refresh OAuth token if it is expired

--- a/src/Api/ApiRequestor.php
+++ b/src/Api/ApiRequestor.php
@@ -8,7 +8,7 @@ use MBLSolutions\LinkModule\Auth\LinkModule;
 
 class ApiRequestor
 {
-    public static ClientInterface $transport;
+    public static ?ClientInterface $transport = null;
 
     /**
      * Create a new API Requestor Instance
@@ -25,7 +25,7 @@ class ApiRequestor
      *
      * @return ClientInterface
      */
-    public function getHttpClient(): ClientInterface
+    public static function getHttpClient(): ?ClientInterface
     {
         return self::$transport;
     }

--- a/src/Api/OAuthResource.php
+++ b/src/Api/OAuthResource.php
@@ -14,11 +14,9 @@ class OAuthResource extends ApiResource
         private string $clientSecret
     )
     {
-        parent::__construct();
+        $client = ApiRequestor::getHttpClient() ?: new Client();
 
-        $client = new Client();
-
-        $this->setApiRequestor(new ApiRequestor($client));
+        parent::__construct($client);
     }
 
     public function getToken(): AccessToken

--- a/src/Auth/Contracts/TokenResolverInterface.php
+++ b/src/Auth/Contracts/TokenResolverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MBLSolutions\LinkModule\Auth\Contracts;
+
+use MBLSolutions\LinkModule\Api\AccessToken;
+
+interface TokenResolverInterface
+{
+    public function resolveToken(): AccessToken;
+}

--- a/src/Auth/TokenResolver.php
+++ b/src/Auth/TokenResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MBLSolutions\LinkModule\Auth;
+
+use MBLSolutions\LinkModule\Api\AccessToken;
+use MBLSolutions\LinkModule\Api\OAuthResource;
+use MBLSolutions\LinkModule\Auth\Contracts\TokenResolverInterface;
+
+class TokenResolver implements TokenResolverInterface
+{
+    public function __construct(
+        private string $tokenUri,
+
+        private string $clientId,
+
+        private string $clientSecret
+    )
+    {
+    }
+
+    public function resolveToken(): AccessToken
+    {
+        $resource = new OAuthResource(
+            tokenUri: $this->tokenUri,
+            clientId: $this->clientId,
+            clientSecret: $this->clientSecret
+        );
+
+        return $resource->getToken();
+    }
+}

--- a/tests/Unit/Auth/LinkModuleTest.php
+++ b/tests/Unit/Auth/LinkModuleTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Auth;
 
-use MBLSolutions\LinkModule\Api\OAuthResource;
 use MBLSolutions\LinkModule\Auth\LinkModule;
+use MBLSolutions\LinkModule\Auth\TokenResolver;
 use MBLSolutions\LinkModule\Exceptions\AuthenticationException;
 use Tests\TestCase;
 
@@ -20,22 +20,54 @@ class LinkModuleTest extends TestCase
     /** @test */
     public function authenticates_with_oauth_token(): void
     {
-        $oauthClient = new OAuthResource(
+        $this->mockExpectedHttpResponse([
+            'access_token' => 'test access token',
+            'expires_in' => 3600,
+            'token_type' => 'Bearer'
+        ]);
+
+        $tokenResolver = new TokenResolver(
             tokenUri: 'https://test.auth.eu-west-2.amazoncognito.com/oauth2/token',
             clientId: 'test',
             clientSecret: 'test'
         );
 
-        $this->mockExpectedHttpResponse([
-            'access_token' => 'Bearer test access token',
-            'expires_in' => 3600,
-            'token_type' => 'Bearer'
-        ]);
+        LinkModule::setTokenResolver($tokenResolver);
 
-        $token = $oauthClient->getToken();
+        $token = $tokenResolver->resolveToken();
 
         LinkModule::setToken($token);
 
         $this->assertEquals('Bearer test access token', LinkModule::getToken());
+    }
+
+    /** @test */
+    public function it_refreshes_expired_token(): void
+    {
+        $this->mockExpectedHttpResponse([
+            'access_token' => 'expired access token',
+            'expires_in' => 0,
+            'token_type' => 'Bearer'
+        ]);
+
+        $tokenResolver = new TokenResolver(
+            tokenUri: 'https://test.auth.eu-west-2.amazoncognito.com/oauth2/token',
+            clientId: 'test',
+            clientSecret: 'test'
+        );
+
+        LinkModule::setTokenResolver($tokenResolver);
+
+        $token = $tokenResolver->resolveToken();
+
+        LinkModule::setToken($token);
+
+        $this->mockExpectedHttpResponse([
+            'access_token' => 'refreshed access token',
+            'expires_in' => 0,
+            'token_type' => 'Bearer'
+        ]);
+
+        $this->assertEquals('Bearer refreshed access token', LinkModule::getToken());
     }
 }


### PR DESCRIPTION
# v0.1.2

+ Move OAuth logic into TokenResolver task
+ Fix mocked HTTP responses in tests